### PR TITLE
Add renovate config for repository.

### DIFF
--- a/.github/workflows/renovate_linting.yml
+++ b/.github/workflows/renovate_linting.yml
@@ -1,0 +1,12 @@
+name: Renovate Config Linting
+on: [pull_request]
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint renovate config # Validates changes to renovate.json config file
+        uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
+        with:
+          config_file_path: 'renovate.json'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    ":dependencyDashboard",
+    ":rebaseStalePrs"
+  ],
+  "schedule": [
+    "before 3am every weekday" 
+  ],
+  "enabledManagers": [
+    "npm",
+    "dockerfile",
+    "github-actions"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["babel"],
+      "matchPackagePrefixes": ["@babel", "babel-"],
+      "groupName": "Babel"
+    },
+    {
+      "matchPackageNames": ["eslint"],
+      "matchPackagePrefixes": ["eslint-"],
+      "groupName": "Eslint"
+    },
+    {
+      "matchPackageNames": ["jest"],
+      "matchPackagePrefixes": ["jest-"],
+      "groupName": "Jest"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "Minor Packages",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #24 

 - [x] I have read the Adding Renovate to Existing Projects guide.
 - [x] I have assigned this issue to myself avoid duplicating efforts with other potential contributors.
 - [x] I have verified this repository does not already have Renovate configured (or proposed in an open PR by another contributor).
- [x]  If the renovate[bot] account has already auto-filed a Configure Renovate PR in this repository, I confirm that I will create a separate PR under my own GitHub account, using the initial PR as inspiration.
 - [x] I confirm that I have added Renovate linting to this project's existing CI pipeline, or have created a new linting workflow if one doesn't already exist.
 - [x] If this repository is currently configured to use GitHub's Dependabot, my PR will also deprecate support for Dependabot in order to avoid conflicts with Renovate.